### PR TITLE
fix: make secp module `pub` to allow usage on snos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,4 +58,4 @@ warnings = "deny"
 future-incompatible = "deny"
 nonstandard-style = "deny"
 rust-2018-idioms = "deny"
-unused = "deny"
+unused = { level = "deny", priority = -1 }

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -32,7 +32,7 @@ use crate::transaction::transaction_utils::update_remaining_gas;
 use crate::versioned_constants::{EventLimits, VersionedConstants};
 
 pub mod hint_processor;
-mod secp;
+pub mod secp;
 
 #[cfg(test)]
 #[path = "syscalls_test.rs"]
@@ -686,10 +686,8 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![
-                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                    .map_err(SyscallExecutionError::from)?,
-            ],
+            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                .map_err(SyscallExecutionError::from)?],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/mod.rs
+++ b/crates/blockifier/src/execution/syscalls/mod.rs
@@ -686,8 +686,10 @@ pub fn keccak(
 
     if remainder != 0 {
         return Err(SyscallExecutionError::SyscallError {
-            error_data: vec![StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
-                .map_err(SyscallExecutionError::from)?],
+            error_data: vec![
+                StarkFelt::try_from(INVALID_INPUT_LENGTH_ERROR)
+                    .map_err(SyscallExecutionError::from)?,
+            ],
         });
     }
 

--- a/crates/blockifier/src/execution/syscalls/secp.rs
+++ b/crates/blockifier/src/execution/syscalls/secp.rs
@@ -206,10 +206,10 @@ pub fn secp256r1_add(
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct SecpGetPointFromXRequest {
-    x: BigUint,
+    pub x: BigUint,
     // The parity of the y coordinate, assuming a point with the given x coordinate exists.
     // True means the y coordinate is odd.
-    y_parity: bool,
+    pub y_parity: bool,
 }
 
 impl SyscallRequest for SecpGetPointFromXRequest {

--- a/crates/blockifier/src/fee/actual_cost.rs
+++ b/crates/blockifier/src/fee/actual_cost.rs
@@ -189,7 +189,7 @@ impl<'a> ActualCostBuilder<'a> {
         let bouncer_resources = actual_resources.clone();
 
         // Add reverted steps to actual_resources' n_steps for correct fee charge.
-        *actual_resources.0.get_mut(&abi_constants::N_STEPS_RESOURCE.to_string()).unwrap() +=
+        *actual_resources.0.get_mut(abi_constants::N_STEPS_RESOURCE).unwrap() +=
             self.n_reverted_steps;
 
         let tx_info = &self.tx_context.tx_info;

--- a/crates/blockifier/src/state/cached_state_test.rs
+++ b/crates/blockifier/src/state/cached_state_test.rs
@@ -390,7 +390,7 @@ fn global_contract_cache_is_used() {
     let mut state = CachedState::new(DictStateReader::default(), global_cache.clone());
 
     // Assert local cache is initialized empty even if global cache is not empty.
-    assert!(state.class_hash_to_class.get(&class_hash).is_none());
+    assert!(!state.class_hash_to_class.contains_key(&class_hash));
 
     // Check state uses the global cache.
     assert_eq!(state.get_compiled_contract_class(class_hash).unwrap(), contract_class);


### PR DESCRIPTION
Problem:
Currently one cannot use the secp module outside of blockifier.

Solution:
Publicize the `secp` module.